### PR TITLE
user multiarch image as base image.

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/open-cluster-management/builder:go1.15-linux-amd64 AS builder
+FROM registry.ci.openshift.org/open-cluster-management/builder:go1.15-linux AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
ref: open-cluster-management/backlog#11324